### PR TITLE
Fix detection of domain expiration for .io

### DIFF
--- a/Templates/Io.php
+++ b/Templates/Io.php
@@ -75,7 +75,7 @@ class Io extends Regex
             '/Country\s*:(?>[\x20\t]*)(.+)/i' => 'contacts:owner:country',
             '/First Registered\s*:(?>[\x20\t]*)(.+)/i' => 'created',
             '/Last Updated\s*:(?>[\x20\t]*)(.+)/i' => 'changed',
-            '/Expires\s*:(?>[\x20\t]*)(.+)/i' => 'expires',
+            '/(Expires|Expiry)\s*:(?>[\x20\t]*)(.+)/i' => 'expires',
             '/Domain Status\s*:(?>[\x20\t]*)(.+)/i' => 'status',
         ),
         2 => array('/User ID\s*:(?>[\x20\t]*)(.+)/i' => 'contacts:owner:handle',


### PR DESCRIPTION
In my limited testing for a few .io domains registered through the gandi.net registrar, the expires attribute was not being parsed accurately.
